### PR TITLE
将multiprocessing导入的Queue换成queue模块导入的Queue

### DIFF
--- a/src/OpenOPC.py
+++ b/src/OpenOPC.py
@@ -16,7 +16,7 @@ import string
 import socket
 import re
 import Pyro4.core
-from multiprocessing import Queue
+from queue import Queue
 
 __version__ = '1.2.0'
 


### PR DESCRIPTION
if use Queue of multiprocessing will raise exception'time out wait for data',so I replace multiprocessing with queue and it works well in python3.